### PR TITLE
bugfix. get script name.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,14 @@
 import './init';
 import rcInit from './remoteConsole';
+import { getCurrentScriptSrc } from './utils';
 
-// 通过document.currentScript来获取脚本文件名
-const currentScript = document.currentScript;
-if (currentScript !== 0) {
-  const url = currentScript.src;
-  if (url) {
-    const querys = url.replace(/^[^?]+\??/, '').split(/[&?]/).map(q => q.split('='));
-    const queryobj = {};
-    for (let i = 0; i < querys.length; i += 1) {
-      queryobj[querys[i][0]] = querys[i][1];
-    }
-    rcInit(queryobj);
+const url = getCurrentScriptSrc();
+alert(url);
+if (url) {
+  const querys = url.replace(/^[^?]+\??/, '').split(/[&?]/).map(q => q.split('='));
+  const queryobj = {};
+  for (let i = 0; i < querys.length; i += 1) {
+    queryobj[querys[i][0]] = querys[i][1];
   }
+  rcInit(queryobj);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,12 @@
 import './init';
 import rcInit from './remoteConsole';
-import { getErrorStack, urlReg } from './utils';
 
-// 通过错误堆栈来找到触发脚本
-const errorStack = getErrorStack(new Error());
-if (errorStack.length !== 0) {
-  const lastError = errorStack[errorStack.length - 1];
-  // 这里我们默认没有二次堆栈调用
-  const urlmatch = lastError.match(urlReg);
-
-  if (urlmatch.length > 0) {
-    const script = urlmatch[0];
-    const querys = script.replace(/^[^?]+\??/, '').split(/[&?]/).map(q => q.split('='));
+// 通过document.currentScript来获取脚本文件名
+const currentScript = document.currentScript;
+if (currentScript !== 0) {
+  const url = currentScript.src;
+  if (url) {
+    const querys = url.replace(/^[^?]+\??/, '').split(/[&?]/).map(q => q.split('='));
     const queryobj = {};
     for (let i = 0; i < querys.length; i += 1) {
       queryobj[querys[i][0]] = querys[i][1];

--- a/lib/remoteConsole.js
+++ b/lib/remoteConsole.js
@@ -4,11 +4,17 @@ export default function init(params) {
   // if no id, return.
   if (!params.uuid) return;
 
-  const rLog = console.log;
+  // ie8-9 console.xxx is an object
+  if (Function.prototype.bind && window.console && typeof console.log === 'object') {
+    ['log', 'info', 'warn', 'error', 'assert', 'dir', 'clear', 'profile', 'profileEnd'].forEach((method) => {
+      console[method] = Function.prototype.call.bind(console[method], console);
+    });
+  }
+  const rLog = console.log.bind(console);
   let rc;
 
   console.log = function log(...args) {
-    rLog.apply(this, args);
+    rLog(...args);
     if (rc) {
       rc.submit(...args);
     } else if (window.wilddog) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,60 @@ function getErrorStack(error = {}) {
 
 const urlReg = /^(\b(https?|ftp|file):\/\/)?[-A-Za-z0-9+&@#/%=~_|!:,.;]+(\?[-A-Za-z0-9+&@#/%=~_|]+)?/gi;
 
+function getCurrentScriptSrc() {
+  // for firefox, chrome, edge, some mobile browser
+  //   see: http://caniuse.com/#search=document.currentScript
+  if (document.currentScript) return document.currentScript.src;
+  const err = new Error();
+  // all firefox
+  //   see: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName
+  if (err.fileName) return err.fileName;
+  // process stack
+  let stack;
+  if (err.stack) {
+    stack = err.stack;
+  } else {
+    // ie, error.stack gets the trace information when the error is raised
+    try {
+      /* eslint-disable */
+      a.b.c();
+      /* eslint-enable */
+    } catch (e) {
+      stack = e.stack;
+      if (window.opera) {
+        // opera 9 has no e.stack, but e.backtrace, use e.toString()
+        stack = (String(err).match(/of linked script \S+/g) || []).join(' ');
+      }
+    }
+  }
+  if (stack) {
+    // if we get stack string, examples:
+    // chrome23:
+    //  at http://113.93.50.63/data.js:4:1
+    // firefox17:
+    // @http://113.93.50.63/query.js:4
+    // opera12:
+    // @http://113.93.50.63/data.js:4
+    // IE10:
+    //   at Global code (http://113.93.50.63/data.js:4:1)
+    //
+    stack = stack.split(/[@ ]/g).pop(); // get content after last line, last space or last @
+    stack = stack[0] === '(' ? stack.slice(1, -1) : stack;
+    return stack.replace(/(:\d+)?:\d+$/i, ''); // remove line number and char number
+  }
+  // otherwise, for ie8-10, search in head tag
+  const nodes = document.head.getElementsByTagName('script');
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = nodes[i];
+    if (node.readyState === 'interactive') {
+      return node.src;
+    }
+  }
+  return null;
+}
+
 export {
   getErrorStack,
   urlReg,
+  getCurrentScriptSrc,
 };


### PR DESCRIPTION
GUGU使用了url query的语法来确定传入参数。所以，如何获得gugu这个脚本的文件名是一个很关键的地方。

版本1的时候，我使用了遍历`script`标签的方法，从中获取包含`remoteConsole`字段的脚本名，后来，项目更迭，更换名字，我就得重写这段代码，后来我想到，若用户自己有本地版本的gugu，那么这段代码将失效，所以这里必须将这个功能和`remoteConsole`之类的字符串解耦。

后来我尝试了如下方案：

方案1：
```javascript
var filepath;
(function(){ 
    var scripts = document.getElementsByTagName('script'); 
    filepath = scripts[ scripts.length-1 ].src; 
}());
```
这段代码的核心在于，使用`(function(){})()`来迅速运行代码，因为js加载的机制，导致最后一个script标签肯定是当前的这个文件，但是有个问题，这段代码执行的script必须是同步加载，也就是说需要放在head中才能生效，有局限性。

方案2：
```javascript
var filepath = (new Error()).fileName;
```
这个方案核心在于使用了`Error`类型的`fileName`属性，这是个十分简洁有效又优雅的方案，可惜的是，当前只有firefox才支持这个属性，故排除。

方案3：
```javascript
var stacks = (new Error()).stack.split('\n');
var lastStack = stacks[stacks.length - 1];

// process lastStack
```
这个方案的核心在于，可以通过建立一个`Error`类型来获取堆栈，然后分析最底层的堆栈中的脚本url，这是一个最终的解决方案，问题也有，就是各个浏览器的stack格式不同，分析十分繁琐，但似乎是个路线，所以我在上个版本中使用的是这个方案，但是在iOS端浏览器出现了兼容性问题。

方案4：
```javascript
var currentScript = document.currentScript;
var filepath = currentScript.src;
```
这个方案跟方案2一样，十分出色，并且兼容性也不错，然而，万恶的ie跳出来了，`document.currentScript`在ie中不存在。

方案5:
```javascript
const nodes = document.head.getElementsByTagName('script');
for (let i = 0; i < nodes.length; i += 1) {
  const node = nodes[i];
  if (node.readyState === 'interactive') {
    return node.src;
  }
}
```
这个方案可以在ie8-10中运行，ie的脚本加载会去更新`readyState`字段，只要遍历这个字段，即可得知哪个脚本正在运行，然而ie11把这个字段给去掉了。。去掉了。。这个方案其实挺好的，但是无法在异步和回调中执行。

--------

如上所述，我只能打算自己写一个功能函数来覆盖这个功能。。。

最终，我得到了如下函数，这个函数在`utils.js`中：

```javascript
function getCurrentScriptSrc() {
  // for firefox, chrome, edge, some mobile browser
  //   see: http://caniuse.com/#search=document.currentScript
  if (document.currentScript) return document.currentScript.src;
  const err = new Error();
  // all firefox
  //   see: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName
  if (err.fileName) return err.fileName;
  // process stack
  let stack;
  if (err.stack) {
    stack = err.stack;
  } else {
    // ie, error.stack gets the trace information when the error is raised
    try {
      /* eslint-disable */
      a.b.c();
      /* eslint-enable */
    } catch (e) {
      stack = e.stack;
      if (window.opera) {
        // opera 9 has no e.stack, but e.backtrace, use e.toString()
        stack = (String(err).match(/of linked script \S+/g) || []).join(' ');
      }
    }
  }
  if (stack) {
    // if we get stack string, examples:
    // chrome23:
    //  at http://113.93.50.63/data.js:4:1
    // firefox17:
    // @http://113.93.50.63/query.js:4
    // opera12:
    // @http://113.93.50.63/data.js:4
    // IE10:
    //   at Global code (http://113.93.50.63/data.js:4:1)
    //
    stack = stack.split(/[@ ]/g).pop(); // get content after last line, last space or last @
    stack = stack[0] === '(' ? stack.slice(1, -1) : stack;
    return stack.replace(/(:\d+)?:\d+$/i, ''); // remove line number and char number
  }
  // otherwise, for ie8-10, search in head tag
  const nodes = document.head.getElementsByTagName('script');
  for (let i = 0; i < nodes.length; i += 1) {
    const node = nodes[i];
    if (node.readyState === 'interactive') {
      return node.src;
    }
  }
  return null;
}
```